### PR TITLE
Adding a value for the "NotBefore" attribute to rotated secrets.

### DIFF
--- a/src/ISecret.cs
+++ b/src/ISecret.cs
@@ -9,15 +9,16 @@ public interface ISecret
     {
         SecretClient Client { get; }
 
+        string Name { get; }
+
         IDictionary<string, string> Tags { get; }
 
+        // The following values are custom tags we apply as metadata for the secret rotation
         string Type { get; }
 
         string ValidityPeriodDays { get; }
 
         string ExpiresInDays { get; }
-
-        string Name { get; }
 
         string ResourceName { get; }
 

--- a/src/Rotators/SecretRotator.cs
+++ b/src/Rotators/SecretRotator.cs
@@ -68,6 +68,7 @@ namespace Microsoft.KeyVault
             }
 
             newSecret.Properties.ExpiresOn = DateTime.UtcNow.AddDays(int.Parse(secret.ValidityPeriodDays));
+            newSecret.Properties.NotBefore = DateTime.UtcNow;
             secret.Client.SetSecret(newSecret);
         }
     }

--- a/src/Secret.cs
+++ b/src/Secret.cs
@@ -17,7 +17,8 @@ namespace Microsoft.KeyVault
         private const string SubscriptionIdTagKey = "SubscriptionId";
         private const string ValidityPeriodDaysTagKey = "ValidityPeriodDays";
         private const string ExpiresInDaysTagKey = "ExpiresInDays";
-        private KeyVaultSecret keyVaultSecret;
+
+        private readonly KeyVaultSecret keyVaultSecret;
 
         public Secret(string secretName, string keyVaultName)
         {


### PR DESCRIPTION
An application we use requires that the 'nbf' or 'NotBefore' attribute be valid and in-time for use of certain secrets. Currently, the keyvault secret rotator does not set this value, so we cannot use secrets rotated by it without manual intervention. This change adds a value for the 'nbf' secret attribute, setting it to the time at which the secret is rotated.